### PR TITLE
Correcting mispellings in contour_plot for localizer and _unpack for waterfaller

### DIFF
--- a/cfod/routines/localizer.py
+++ b/cfod/routines/localizer.py
@@ -54,6 +54,6 @@ class Localizer:
 
     def contour_plot(self):
         """
-        Draw the localization coutour plot
+        Draw the localization contour plot
         """
         localization.countours(data=self.datafile)

--- a/cfod/routines/localizer.py
+++ b/cfod/routines/localizer.py
@@ -52,7 +52,7 @@ class Localizer:
         """
         localization.plot(data=self.datafile)
 
-    def coutour_plot(self):
+    def countour_plot(self):
         """
         Draw the localization coutour plot
         """

--- a/cfod/routines/localizer.py
+++ b/cfod/routines/localizer.py
@@ -52,7 +52,7 @@ class Localizer:
         """
         localization.plot(data=self.datafile)
 
-    def countour_plot(self):
+    def contour_plot(self):
         """
         Draw the localization coutour plot
         """

--- a/cfod/routines/waterfaller.py
+++ b/cfod/routines/waterfaller.py
@@ -27,7 +27,7 @@ class Waterfaller:
         """
         Unpack the attributes of the datafile.
         """
-        self.data = self.datafile["frb"]
+        self.datafile = self.datafile["frb"]
         self.eventname = self.datafile.attrs["tns_name"].decode()
         self.wfall = self.datafile["wfall"][:]
         self.model_wfall = self.datafile["model_wfall"][:]


### PR DESCRIPTION
Corrected misspelling of coutour to contour in localizer, and changed self.data to self.datafile in unpack for waterfaller.

## Description
Some misspellings in the Localizer and Waterfaller functions. Specially the unpack. 

## Related Issue
This solves issue #18 .  

## Motivation and Context
The function and variable name was misspelled, so the function was not easy to find in the localizer. Also the variable name was
wrong in the waterfaller _unpack function causing any instance of the class to fail to be created. 

## How Has This Been Tested?
Simple misspelling when calling the function, no implementation was changed.


## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
